### PR TITLE
feat: close the split panel based on the minimum size property 

### DIFF
--- a/stories/split.stories.tsx
+++ b/stories/split.stories.tsx
@@ -11,6 +11,8 @@ export default {
     initialSeparation: '50%',
     orientation: 'horizontal',
     sideSeparation: 'end',
+    initialClosed: false,
+    minimalSize: undefined,
   },
   argTypes: {
     onChange: { action: 'handle' },


### PR DESCRIPTION
closed the panel on load when the panel size is less than or equal to the minimum size,
This action is not effective anymore once the user touched the splitter by clicking on it.
