### PR TITLE
fix: specify base URL for Storybook in gh-pages build

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -8,7 +8,8 @@ const config: StorybookViteConfig = {
   staticDirs: [],
   addons: ['@storybook/addon-essentials', '@storybook/addon-storysource'],
   async viteFinal(config, options) {
-    config.base = '/storybook/';
+    const base = process.env.VITE_BASE || '/';
+    config.base = base + 'storybook/';
     return config;
   },
 };

--- a/src/app/main.tsx
+++ b/src/app/main.tsx
@@ -19,7 +19,7 @@ ReactDOM.render(
             paddingBlock: 5,
           }}
         >
-          <a href="/storybook/">Open Storybook</a>
+          <a href={`${import.meta.env.BASE_URL}storybook/`}>Open Storybook</a>
         </div>
       ) : null}
       <App />


### PR DESCRIPTION
Closes: https://github.com/zakodium-oss/analysis-ui-components/issues/149
