### PR TITLE
refactor(MeasurementExplorer): dropdown items

### DIFF
--- a/src/app/components/MeasurementExplorer.tsx
+++ b/src/app/components/MeasurementExplorer.tsx
@@ -163,7 +163,7 @@ export function MeasurementExplorer(props: MeasurementExplorerProps) {
               display: flex;
             `}
           >
-            Flip &quot; x &quot; axis:
+            Flip horizontal axis:
             <FaArrowsAltH
               css={css`
                 cursor: pointer;

--- a/src/app/components/MeasurementExplorer.tsx
+++ b/src/app/components/MeasurementExplorer.tsx
@@ -15,7 +15,6 @@ interface ExplorerInfo {
   yVariableName: string;
   flipHorizontalAxis: boolean;
 }
-type XOrY = keyof Pick<ExplorerInfo, 'xVariableName' | 'yVariableName'>;
 
 export function MeasurementExplorer(props: MeasurementExplorerProps) {
   const {
@@ -47,7 +46,7 @@ export function MeasurementExplorer(props: MeasurementExplorerProps) {
       return formatVarKey + label + formatUnit;
     }
     const { variables } = data[info.dataIndex];
-    const oppositeAxis: XOrY = axis === 'x' ? 'yVariableName' : 'xVariableName';
+    const oppositeAxis = axis === 'x' ? 'yVariableName' : 'xVariableName';
     return Object.keys(variables).map((d) => {
       if (d !== info[oppositeAxis]) {
         return (


### PR DESCRIPTION
Display some information in the dropdown (it uses the variable id, label and units).  The id is for avoiding confusion between variables with the same label (say both are "Transmittance").

But should we lowercase the label, uppercasing the first letter, or leave them as they appear in the files?

**Before**

![Screenshot from 2022-11-04 20-26-11](https://user-images.githubusercontent.com/29411936/200059092-ce1b88a4-d2ff-4e2b-9104-931f39508887.png)

**After changes**


![Screenshot from 2022-11-04 20-19-27](https://user-images.githubusercontent.com/29411936/200058029-ab40df68-6489-457f-bbe3-9af373a347c8.png)
