### PR TITLE
fix: log errors from loader

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@lukeed/uuid": "^2.0.0",
         "@popperjs/core": "^2.11.6",
         "@tanstack/react-table": "^8.5.22",
-        "biologic-converter": "^0.4.0",
+        "biologic-converter": "^0.5.0",
         "cheminfo-types": "^1.4.0",
         "filelist-utils": "^1.2.0",
         "immer": "^9.0.16",
@@ -44,14 +44,14 @@
         "@types/react-dom": "^18.0.8",
         "@types/react-inspector": "^4.0.2",
         "@vitejs/plugin-react": "^2.2.0",
-        "@vitest/coverage-c8": "^0.24.5",
+        "@vitest/coverage-c8": "^0.25.1",
         "cheminfo-font": "^1.9.0",
         "cross-env": "^7.0.3",
         "eslint": "^8.27.0",
         "eslint-config-zakodium": "^7.0.0",
         "isotopic-distribution": "^1.4.15",
         "ml-signal-processing": "^0.5.2",
-        "ml-spectra-processing": "^11.13.0",
+        "ml-spectra-processing": "^11.14.0",
         "ms-spectrum": "^1.6.15",
         "prettier": "^2.7.1",
         "react": "^18.2.0",
@@ -65,7 +65,7 @@
         "rimraf": "^3.0.2",
         "typescript": "^4.8.4",
         "vite": "^3.2.3",
-        "vitest": "^0.24.5"
+        "vitest": "^0.25.1"
       },
       "peerDependencies": {
         "react": ">=18.0.0",
@@ -2394,9 +2394,9 @@
       }
     },
     "node_modules/@types/chai": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.3.tgz",
-      "integrity": "sha512-hC7OMnszpxhZPduX+m+nrx+uFoLkWOMiR4oa/AZF3MuSETYTZmFfJAHqZEM8MVlvfG7BEUcgvtwoCTxBp6hm3g==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.4.tgz",
+      "integrity": "sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==",
       "dev": true
     },
     "node_modules/@types/chai-subset": {
@@ -2827,13 +2827,13 @@
       }
     },
     "node_modules/@vitest/coverage-c8": {
-      "version": "0.24.5",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-c8/-/coverage-c8-0.24.5.tgz",
-      "integrity": "sha512-955yK/SdSBZPYrSXgXB0F+0JnOX5EY9kSL7ywJ4rNajmkFUhwLjuKm13Xb6YKSyIY/g5WvbBnyowqfNRxBJ3ww==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-c8/-/coverage-c8-0.25.1.tgz",
+      "integrity": "sha512-gpl5QNaNeIN0mfRiosCqBFoZcizb5GA458TDnOQXkGDc4kklazxn70u9evGfV62wiiAUfGGebgRhxlBkAa6m6g==",
       "dev": true,
       "dependencies": {
         "c8": "^7.12.0",
-        "vitest": "0.24.5"
+        "vitest": "0.25.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
@@ -2876,6 +2876,15 @@
       "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/ajv": {
@@ -3195,13 +3204,12 @@
       "integrity": "sha512-nbE1WxOTTrUWIfsfZ4aHGYu5DOuNkbxGokjV6Z2kxfJK3uaAb8zNK1muzOeipoLHZjInT4Br88BHpzevc681xA=="
     },
     "node_modules/biologic-converter": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/biologic-converter/-/biologic-converter-0.4.0.tgz",
-      "integrity": "sha512-Ck/oJXDy84tD0k4zo4+vqEw60ADktjPmue4A8hxrx67rcToX5fvVHs0EkO0WlnhSjk20b5DeWzRbm9k+jHBwMA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/biologic-converter/-/biologic-converter-0.5.0.tgz",
+      "integrity": "sha512-R+6IRpeomJjjRVvbTgHx3oeMSrLhNQ2wFWR32C7TSwxrbsqSoVGTqLjE0/Dh7ihNbEIc8I6pGPRqcZ4aVEDn/w==",
       "dependencies": {
         "cheminfo-types": "^1.4.0",
         "ensure-string": "^1.2.0",
-        "filelist-utils": "^1.0.1",
         "iobuffer": "^5.2.1"
       }
     },
@@ -3451,14 +3459,14 @@
       ]
     },
     "node_modules/chai": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
-      "integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
+      "integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
       "dev": true,
       "dependencies": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.2",
-        "deep-eql": "^3.0.1",
+        "deep-eql": "^4.1.2",
         "get-func-name": "^2.0.0",
         "loupe": "^2.3.1",
         "pathval": "^1.1.1",
@@ -4066,15 +4074,15 @@
       }
     },
     "node_modules/deep-eql": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.2.tgz",
+      "integrity": "sha512-gT18+YW4CcW/DBNTwAmqTtkJh7f9qqScu2qFVlx7kCoeY9tlBu9cUcr7+I+Z/noG8INehS3xQgLpTtd/QUTn4w==",
       "dev": true,
       "dependencies": {
         "type-detect": "^4.0.0"
       },
       "engines": {
-        "node": ">=0.12"
+        "node": ">=6"
       }
     },
     "node_modules/deep-is": {
@@ -6729,9 +6737,9 @@
       }
     },
     "node_modules/loupe": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.5.tgz",
-      "integrity": "sha512-KNGVjhsXDxvY/cYE8GNi7SBaJSfJIT+/+/8GlprqBXpoU6cSR7/RT7OBJOsoYtyxq0L3q6oIcO8tX7dbEEXr3A==",
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
+      "integrity": "sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==",
       "dev": true,
       "dependencies": {
         "get-func-name": "^2.0.0"
@@ -7274,16 +7282,16 @@
       }
     },
     "node_modules/ml-spectra-processing": {
-      "version": "11.13.0",
-      "resolved": "https://registry.npmjs.org/ml-spectra-processing/-/ml-spectra-processing-11.13.0.tgz",
-      "integrity": "sha512-4yO+rlNxtYF2taUwF0mGXDe5i1ZMb2N5E/Uj4orcfYGuZJZcN2b5ZggR+8PtxVZYT2GYHKXlxs65nlihiqCujA==",
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/ml-spectra-processing/-/ml-spectra-processing-11.14.0.tgz",
+      "integrity": "sha512-U3aT0VXyf9xtiu4QVA+LnZkrsheilusWdQVS3Yki7Zm3UnfaTlQgDsIJ/UYGJTB2wCeoOjnHd2cCJ7W8S1hBpg==",
       "dependencies": {
         "binary-search": "^1.3.6",
         "cheminfo-types": "^1.4.0",
         "fft.js": "^4.0.4",
         "is-any-array": "^2.0.0",
         "median-quickselect": "^1.0.1",
-        "ml-matrix": "^6.10.2",
+        "ml-matrix": "^6.10.4",
         "ml-xsadd": "^2.0.0",
         "spline-interpolator": "^1.0.0"
       }
@@ -9829,17 +9837,20 @@
       }
     },
     "node_modules/vitest": {
-      "version": "0.24.5",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.24.5.tgz",
-      "integrity": "sha512-zw6JhPUHtLILQDe5Q39b/SzoITkG+R7hcFjuthp4xsi6zpmfQPOZcHodZ+3bqoWl4EdGK/p1fuMiEwdxgbGLOA==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.25.1.tgz",
+      "integrity": "sha512-eH74h6MkuEgsqR4mAQZeMK9O0PROiKY+i+1GMz/fBi5A3L2ml5U7JQs7LfPU7+uWUziZyLHagl+rkyfR8SLhlA==",
       "dev": true,
       "dependencies": {
         "@types/chai": "^4.3.3",
         "@types/chai-subset": "^1.3.3",
         "@types/node": "*",
+        "acorn": "^8.8.0",
+        "acorn-walk": "^8.2.0",
         "chai": "^4.3.6",
         "debug": "^4.3.4",
         "local-pkg": "^0.4.2",
+        "source-map": "^0.6.1",
         "strip-literal": "^0.4.2",
         "tinybench": "^2.3.1",
         "tinypool": "^0.3.0",
@@ -9878,6 +9889,15 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/warning": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@lukeed/uuid": "^2.0.0",
     "@popperjs/core": "^2.11.6",
     "@tanstack/react-table": "^8.5.22",
-    "biologic-converter": "^0.4.0",
+    "biologic-converter": "^0.5.0",
     "cheminfo-types": "^1.4.0",
     "filelist-utils": "^1.2.0",
     "immer": "^9.0.16",

--- a/package.json
+++ b/package.json
@@ -96,14 +96,14 @@
     "@types/react-dom": "^18.0.8",
     "@types/react-inspector": "^4.0.2",
     "@vitejs/plugin-react": "^2.2.0",
-    "@vitest/coverage-c8": "^0.24.5",
+    "@vitest/coverage-c8": "^0.25.1",
     "cheminfo-font": "^1.9.0",
     "cross-env": "^7.0.3",
     "eslint": "^8.27.0",
     "eslint-config-zakodium": "^7.0.0",
     "isotopic-distribution": "^1.4.15",
     "ml-signal-processing": "^0.5.2",
-    "ml-spectra-processing": "^11.13.0",
+    "ml-spectra-processing": "^11.14.0",
     "ms-spectrum": "^1.6.15",
     "prettier": "^2.7.1",
     "react": "^18.2.0",
@@ -117,7 +117,7 @@
     "rimraf": "^3.0.2",
     "typescript": "^4.8.4",
     "vite": "^3.2.3",
-    "vitest": "^0.24.5"
+    "vitest": "^0.25.1"
   },
   "repository": {
     "type": "git",

--- a/src/app-data/loaders/biologicLoader.ts
+++ b/src/app-data/loaders/biologicLoader.ts
@@ -26,29 +26,29 @@ export async function biologicLoader(fileCollection: FileCollection) {
     try {
       if (file.name.endsWith('.mpr')) {
         const mpr = parseMPR(await file.arrayBuffer());
-        const prepare = templateFromFile(file);
+        const info = templateFromFile(file);
         // puts the "useful" variables at x and y for default plot.
         const variables = preferredXY(
-          prepare.meta.technique,
+          mpr.settings.variables.technique,
           mpr.data.variables,
         );
         result = {
-          ...prepare,
+          ...info,
           meta: mpr.settings.variables,
           data: [{ variables }],
         };
         measurements[kind].entries.push(result);
       } else if (file.name.endsWith('.mpt')) {
         const mpt = parseMPT(await file.arrayBuffer());
-        const prepare = templateFromFile(file);
+        const info = templateFromFile(file);
         if (mpt.data?.variables) {
           // puts the "useful" variables at x and y for default plot.
           const variables = preferredXY(
-            prepare.meta?.technique,
+            mpt.settings?.technique,
             mpt.data.variables,
           );
           result = {
-            ...prepare,
+            ...info,
             meta: mpt.settings?.variables || {},
             data: [{ variables }],
           };

--- a/src/app-data/loaders/biologicLoader.ts
+++ b/src/app-data/loaders/biologicLoader.ts
@@ -20,7 +20,6 @@ export async function biologicLoader(fileCollection: FileCollection) {
   const measurements = getEmptyMeasurements();
   const kind: MeasurementKind = 'iv';
   const logs: ParserLog[] = [];
-  let result: MeasurementBase;
 
   for (const file of fileCollection.files) {
     try {
@@ -32,7 +31,7 @@ export async function biologicLoader(fileCollection: FileCollection) {
           mpr.settings.variables.technique,
           mpr.data.variables,
         );
-        result = {
+        const result: MeasurementBase = {
           ...info,
           meta: mpr.settings.variables,
           data: [{ variables }],
@@ -47,7 +46,7 @@ export async function biologicLoader(fileCollection: FileCollection) {
             mpt.settings?.technique,
             mpt.data.variables,
           );
-          result = {
+          const result: MeasurementBase = {
             ...info,
             meta: mpt.settings?.variables || {},
             data: [{ variables }],
@@ -104,7 +103,7 @@ function preferredXY(
       break;
     }
     default:
-      return variables;
+      break;
   }
   return variables;
 }
@@ -121,7 +120,7 @@ function setDefault(
   label: string,
   storeAt: 'x' | 'y',
 ) {
-  for (let varum in variables) {
+  for (const varum in variables) {
     // find the key that has the label (or skip if not found)
     if (
       variables[varum].label === label && //if not already at the right key
@@ -133,7 +132,7 @@ function setDefault(
         // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
         delete variables[varum];
       } else {
-        // if the storeAt is already occupied, we swap the two
+        // if the storeAt is already occupied, swap the two
         const originalX = variables[storeAt];
         const newX = variables[varum];
         variables[storeAt] = newX;

--- a/src/app-data/loaders/utility/parserLog.ts
+++ b/src/app-data/loaders/utility/parserLog.ts
@@ -1,0 +1,31 @@
+export interface ParserLog {
+  kind: 'error' | 'warn' | 'info' | 'debug' | 'summary';
+  parser: string;
+  message: string;
+  relativePath?: string;
+  error?: Error;
+}
+
+export function createLogEntry(info: Partial<ParserLog>): ParserLog {
+  const {
+    parser = 'biologic-converter',
+    kind = 'error',
+    message = 'Error parsing biologic experiment.',
+    error,
+    relativePath,
+  } = info;
+
+  const log: ParserLog = {
+    parser,
+    kind,
+    message,
+  };
+
+  if (error) {
+    log.error = error;
+  }
+  if (relativePath) {
+    log.relativePath = relativePath;
+  }
+  return log;
+}

--- a/src/app-data/loaders/utility/parserLog.ts
+++ b/src/app-data/loaders/utility/parserLog.ts
@@ -1,7 +1,11 @@
 export interface ParserLog {
   kind: 'error' | 'warn' | 'info' | 'debug' | 'summary';
+  /* name of the parser or converter*/
   parser: string;
   message: string;
+  /* if the parser has branches for text, binary, etc. */
+  branch?: string;
+  /* from FileCollectionItem or other*/
   relativePath?: string;
   error?: Error;
 }
@@ -9,6 +13,7 @@ export interface ParserLog {
 export function createLogEntry(info: Partial<ParserLog>): ParserLog {
   const {
     parser = 'biologic-converter',
+    branch,
     kind = 'error',
     message = 'Error parsing biologic experiment.',
     error,
@@ -26,6 +31,9 @@ export function createLogEntry(info: Partial<ParserLog>): ParserLog {
   }
   if (relativePath) {
     log.relativePath = relativePath;
+  }
+  if (branch) {
+    log.branch = branch;
   }
   return log;
 }

--- a/src/app-data/loaders/utility/templateFromFile.ts
+++ b/src/app-data/loaders/utility/templateFromFile.ts
@@ -2,8 +2,9 @@ import { v4 } from '@lukeed/uuid';
 import type { FileCollectionItem } from 'filelist-utils';
 
 /**
- * loaders accepting a FileCollectionItem as input can use this function
- * to create a template for the MeasurementBase (part)
+ * creates a template for the MeasurementBase (part)
+ * generated from just the file metadata only and id
+ * @param obj - file as collection item.
  */
 export function templateFromFile({
   name,

--- a/src/app-data/loaders/utility/templateFromFile.ts
+++ b/src/app-data/loaders/utility/templateFromFile.ts
@@ -1,0 +1,20 @@
+import { v4 } from '@lukeed/uuid';
+import type { FileCollectionItem } from 'filelist-utils';
+
+/**
+ * loaders accepting a FileCollectionItem as input can use this function
+ * to create a template for the MeasurementBase (part)
+ */
+export function templateFromFile({
+  name,
+  relativePath,
+  lastModified,
+  size,
+}: FileCollectionItem) {
+  return {
+    id: v4(),
+    filename: name,
+    path: relativePath,
+    info: { lastModified, size },
+  };
+}


### PR DESCRIPTION
This is currently the output (I tweaked one line that is failing in the getMeasurements, already filed the bug.):

* File loading
![Screenshot from 2022-11-11 12-31-06](https://user-images.githubusercontent.com/29411936/201331857-1825dab3-8f14-4627-aea9-c189e562c63a.png)

* File errors (unsupported techniques.)
![Screenshot from 2022-11-11 12-31-18](https://user-images.githubusercontent.com/29411936/201331900-83513229-d6fa-4c96-bdff-d2228e2b1dd2.png)

@lpatiny 

We may need to reduce the number of files in the link as it is several MBs and xhr requests ? Takes a while here at least.