### PR TITLE
refactor: harmonise loaders

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@lukeed/uuid": "^2.0.0",
         "@popperjs/core": "^2.11.6",
         "@tanstack/react-table": "^8.5.22",
-        "biologic-converter": "^0.4.0",
+        "biologic-converter": "^0.5.0",
         "cheminfo-types": "^1.4.0",
         "filelist-utils": "^1.2.0",
         "immer": "^9.0.16",
@@ -3204,13 +3204,12 @@
       "integrity": "sha512-nbE1WxOTTrUWIfsfZ4aHGYu5DOuNkbxGokjV6Z2kxfJK3uaAb8zNK1muzOeipoLHZjInT4Br88BHpzevc681xA=="
     },
     "node_modules/biologic-converter": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/biologic-converter/-/biologic-converter-0.4.0.tgz",
-      "integrity": "sha512-Ck/oJXDy84tD0k4zo4+vqEw60ADktjPmue4A8hxrx67rcToX5fvVHs0EkO0WlnhSjk20b5DeWzRbm9k+jHBwMA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/biologic-converter/-/biologic-converter-0.5.0.tgz",
+      "integrity": "sha512-R+6IRpeomJjjRVvbTgHx3oeMSrLhNQ2wFWR32C7TSwxrbsqSoVGTqLjE0/Dh7ihNbEIc8I6pGPRqcZ4aVEDn/w==",
       "dependencies": {
         "cheminfo-types": "^1.4.0",
         "ensure-string": "^1.2.0",
-        "filelist-utils": "^1.0.1",
         "iobuffer": "^5.2.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@lukeed/uuid": "^2.0.0",
     "@popperjs/core": "^2.11.6",
     "@tanstack/react-table": "^8.5.22",
-    "biologic-converter": "^0.4.0",
+    "biologic-converter": "^0.5.0",
     "cheminfo-types": "^1.4.0",
     "filelist-utils": "^1.2.0",
     "immer": "^9.0.16",

--- a/src/app-data/DataState.ts
+++ b/src/app-data/DataState.ts
@@ -63,11 +63,12 @@ export const kindsLabel: Record<MeasurementKind, string> = {
 
 export type Loader = (
   fileCollection: FileCollection,
-) => Promise<Partial<Measurements>>;
+  logger?: boolean,
+) => Promise<Measurements>;
 
 export function mergeMeasurements(
-  measurements: Partial<Measurements>,
-  newMeasurements: Partial<Measurements>,
+  measurements: Measurements,
+  newMeasurements: Measurements,
 ) {
   for (const kind in newMeasurements) {
     if (!measurements[kind]) {

--- a/src/app-data/__tests__/getIRMeasurement.ts
+++ b/src/app-data/__tests__/getIRMeasurement.ts
@@ -1,5 +1,4 @@
 import { getTestFileCollection } from '../../utils/test-utils';
-import type { IRMeasurement } from '../IRMeasurement';
 import { getIRAutoPeakPickingEnhancer } from '../enhancers/irAutoPeakPickingEnhancer';
 import { irMeasurementEnhancer } from '../enhancers/irMeasurementEnhancer';
 import { loadMeasurements } from '../loadMeasurements';
@@ -23,5 +22,5 @@ export async function getIRMeasurement() {
     loaders,
     enhancers,
   });
-  return measurements.ir?.entries[0] as IRMeasurement;
+  return measurements.ir.entries[0];
 }

--- a/src/app-data/__tests__/loadMeasurements.test.ts
+++ b/src/app-data/__tests__/loadMeasurements.test.ts
@@ -23,29 +23,28 @@ test('loadMeasurements function', async () => {
     enhancers,
   });
 
-  expect(Object.keys(measurements)).toStrictEqual(['nmr', 'ir', 'uv', 'raman']);
   const { ir, raman, uv } = measurements;
-  expect(ir?.entries).toHaveLength(2);
+  expect(ir.entries).toHaveLength(2);
 
-  expect(ir?.entries[0].peaks).toHaveLength(18);
-  expect(ir?.entries[1].peaks).toHaveLength(42);
-  expect(ir?.entries[0].peaks?.[0]).toStrictEqual({
+  expect(ir.entries[0].peaks).toHaveLength(18);
+  expect(ir.entries[1].peaks).toHaveLength(42);
+  expect(ir.entries[0].peaks?.[0]).toStrictEqual({
     absorbance: 0.16390240095857445,
     kind: 'S',
     transmittance: 0.6856422936,
     wavenumber: 1049.0926378858535,
   });
 
-  expect(raman?.entries).toHaveLength(1);
-  expect(raman?.entries[0].data).toHaveLength(36);
-  expect(raman?.entries[0].data[0].meta).toMatchObject({
+  expect(raman.entries).toHaveLength(1);
+  expect(raman.entries[0].data).toHaveLength(36);
+  expect(raman.entries[0].data[0].meta).toMatchObject({
     xPosition: -4501.903563829787,
     xPositionUnits: '10-6 metres (um)',
     yPosition: -2474.7475,
     yPositionUnits: '10-6 metres (um)',
   });
-  expect(raman?.entries[0].data[0].variables.x.data).toHaveLength(1015);
-  expect(raman?.entries[0].data[0].variables.y.data).toHaveLength(1015);
+  expect(raman.entries[0].data[0].variables.x.data).toHaveLength(1015);
+  expect(raman.entries[0].data[0].variables.y.data).toHaveLength(1015);
 
-  expect(uv?.entries).toHaveLength(2);
+  expect(uv.entries).toHaveLength(2);
 });

--- a/src/app-data/loadMeasurements.ts
+++ b/src/app-data/loadMeasurements.ts
@@ -1,6 +1,6 @@
 import type { FileCollection } from 'filelist-utils';
 
-import { Loader, Measurements, mergeMeasurements } from './DataState';
+import { getEmptyMeasurements, Loader, mergeMeasurements } from './DataState';
 import { enhance } from './enhancers/enhance';
 
 interface LoadOptions {
@@ -12,10 +12,10 @@ export async function loadMeasurements(
   fileCollection: FileCollection,
   options: LoadOptions = {},
 ) {
-  const measurements: Partial<Measurements> = {};
+  const measurements = getEmptyMeasurements();
   const { loaders = [], enhancers = {} } = options;
   for (const loader of loaders) {
-    const loaderData = await loader(fileCollection);
+    const loaderData = await loader(fileCollection, true);
     enhance(loaderData, enhancers);
     mergeMeasurements(measurements, loaderData);
   }

--- a/src/app-data/loaders/spcLoader.ts
+++ b/src/app-data/loaders/spcLoader.ts
@@ -1,34 +1,58 @@
-import { v4 } from '@lukeed/uuid';
 import type { FileCollection } from 'filelist-utils';
 import { parse, guessSpectraType } from 'spc-parser';
 
-import { assert } from '../../utils/assert';
-import type { MeasurementKind, Measurements } from '../DataState';
+import {
+  getEmptyMeasurements,
+  measurementKinds,
+  MeasurementKind,
+  Measurements,
+} from '../DataState';
 import type { MeasurementBase } from '../MeasurementBase';
 
-export async function spcLoader(fileCollection: FileCollection) {
-  const measurements: Partial<Measurements> = {};
+import { ParserLog, createLogEntry } from './utility/parserLog';
+import { templateFromFile } from './utility/templateFromFile';
+
+/**
+ *
+ * @param fileCollection - the dragged file/files
+ * @param logger - whether to log to console or not
+ * @returns - new measurements object to be merged
+ */
+export async function spcLoader(
+  fileCollection: FileCollection,
+  logger?: boolean,
+) {
+  const measurements: Measurements = getEmptyMeasurements();
+  const logs: ParserLog[] = [];
   for (const file of fileCollection) {
-    if (file.name.match(/\.spc$/i)) {
-      const parsed = parse(await file.arrayBuffer());
-      const spectraType: MeasurementKind = guessSpectraType(parsed.meta);
-      if (!measurements[spectraType]) {
-        measurements[spectraType] = { entries: [] };
+    if (/\.spc$/i.test(file.name)) {
+      try {
+        const parsed = parse(await file.arrayBuffer());
+        const spectraType: MeasurementKind = guessSpectraType(parsed.meta);
+        if (measurementKinds.includes(spectraType)) {
+          measurements[spectraType].entries.push({
+            meta: parsed.meta,
+            ...templateFromFile(file),
+            title: parsed.meta.memo,
+            data: parsed.spectra as unknown as MeasurementBase['data'],
+          });
+        }
+      } catch (error) {
+        if (error instanceof Error) {
+          logs.push(
+            createLogEntry({
+              parser: 'spc-parser',
+              relativePath: file.relativePath,
+              error,
+            }),
+          );
+        }
       }
-      assert(
-        measurements[spectraType],
-        'Error while loading, kind is not defined',
-      );
-      measurements[spectraType]?.entries.push({
-        id: v4(),
-        meta: parsed.meta,
-        filename: file.name,
-        path: file.relativePath || '',
-        info: {},
-        title: parsed.meta.memo,
-        data: parsed.spectra as unknown as MeasurementBase['data'],
-      });
     }
+  }
+  if (logger && logs.length > 0) {
+    // eslint-disable-next-line no-console
+    console.error(logs);
   }
   return measurements;
 }

--- a/src/app-data/loaders/utility/parserLog.ts
+++ b/src/app-data/loaders/utility/parserLog.ts
@@ -1,0 +1,39 @@
+export interface ParserLog {
+  kind: 'error' | 'warn' | 'info' | 'debug' | 'summary';
+  /* name of the parser or converter*/
+  parser: string;
+  message: string;
+  /* if the parser has branches for text, binary, etc. */
+  branch?: string;
+  /* from FileCollectionItem or other*/
+  relativePath?: string;
+  error?: Error;
+}
+
+export function createLogEntry(info: Partial<ParserLog>): ParserLog {
+  const {
+    parser = 'biologic-converter',
+    branch,
+    kind = 'error',
+    message = 'Error parsing biologic experiment.',
+    error,
+    relativePath,
+  } = info;
+
+  const log: ParserLog = {
+    parser,
+    kind,
+    message,
+  };
+
+  if (error) {
+    log.error = error;
+  }
+  if (relativePath) {
+    log.relativePath = relativePath;
+  }
+  if (branch) {
+    log.branch = branch;
+  }
+  return log;
+}

--- a/src/app-data/loaders/utility/templateFromFile.ts
+++ b/src/app-data/loaders/utility/templateFromFile.ts
@@ -1,0 +1,21 @@
+import { v4 } from '@lukeed/uuid';
+import type { FileCollectionItem } from 'filelist-utils';
+
+/**
+ * creates a template for the MeasurementBase (part)
+ * generated from just the file metadata only and id
+ * @param obj - file as collection item.
+ */
+export function templateFromFile({
+  name,
+  relativePath,
+  lastModified,
+  size,
+}: FileCollectionItem) {
+  return {
+    id: v4(),
+    filename: name,
+    path: relativePath,
+    info: { lastModified, size },
+  };
+}

--- a/src/app/explorer/MeasurementPlot.tsx
+++ b/src/app/explorer/MeasurementPlot.tsx
@@ -3,7 +3,6 @@ import { useMemo } from 'react';
 import { LineSeries, PlotController } from 'react-plot';
 
 import type { MeasurementBase } from '../../app-data/index';
-
 import { BasicComponent } from '../helpers/react-plot';
 
 type Measurement = Pick<


### PR DESCRIPTION
 The parsers were rewritten with this structure (metacode):
```
anyParser(filecollection, logger?:boolean){
 measurements = getEmptyMeasurements()
  logs = [ ] 
  for(loop over files){
   try{
     // try to parse
   } catch(e){
    // push to logs
   }
  return measurements //with the new ones
}
```



The code changes some previous additions from [4ff5580](https://github.com/zakodium-oss/analysis-ui-components/commit/4ff5580a5818a83bd88c078989a7397c45ee577e), just `assert` for an error log and Partial for full `Measurement` object, that's why I included the template, in case it needs discussion.