### PR TITLE
fix: only show spinner when data is loading

### DIFF
--- a/src/app-data/state/appState.tsx
+++ b/src/app-data/state/appState.tsx
@@ -15,13 +15,21 @@ import { getEmptyAppSettings } from './settings/getEmptyAppSettings';
 import { getEmptyAppView, AppView } from './view/index';
 
 export interface AppState {
+  load: AppLoad;
   data: AppData;
   view: AppView;
   settings: AppSettings;
 }
 
+export interface AppLoad {
+  isLoading: boolean;
+}
+
 function getEmptyAppState(): AppState {
   return {
+    load: {
+      isLoading: false,
+    },
     data: getEmptyAppData(),
     view: getEmptyAppView(),
     settings: getEmptyAppSettings(),

--- a/src/app-data/state/appStateActions.ts
+++ b/src/app-data/state/appStateActions.ts
@@ -11,6 +11,8 @@ type ActionType<Action, Payload = void> = Payload extends void
   : { type: Action; payload: Payload };
 
 export type AppStateAction =
+  | ActionType<'LOAD_START'>
+  | ActionType<'LOAD_STOP'>
   | ActionType<'ADD_MEASUREMENTS', Partial<Measurements>>
   | ActionType<'LOAD_FULL_STATE', AppState>
   | ActionType<

--- a/src/app-data/state/producers/appStateProducer.ts
+++ b/src/app-data/state/producers/appStateProducer.ts
@@ -24,6 +24,12 @@ export const loadFullState: AppStateProducer<'LOAD_FULL_STATE'> = (
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const producers: Record<ActionType, AppStateProducer<any>> = {
+  LOAD_START: (draft) => {
+    draft.load.isLoading = true;
+  },
+  LOAD_STOP: (draft) => {
+    draft.load.isLoading = false;
+  },
   ADD_MEASUREMENTS: addMeasurements,
   SELECT_MEASUREMENT: selectMeasurement,
   SELECT_MEASUREMENT_KIND: selectMeasurementKind,

--- a/src/pages/big-map/MainLayout.tsx
+++ b/src/pages/big-map/MainLayout.tsx
@@ -90,7 +90,7 @@ export default function MainLayout() {
             initialClosed={500}
             controlledSide="end"
           >
-            {measurementKinds.length === 0 ? (
+            {appState.load.isLoading ? (
               <div style={{ width: '100%', height: '100%' }}>
                 <FullSpinner />
               </div>

--- a/src/pages/big-map/helpers/loadFiles.ts
+++ b/src/pages/big-map/helpers/loadFiles.ts
@@ -14,6 +14,7 @@ export async function loadFiles(
   files: File[] | FileCollection,
   dispatch: AppDispatch,
 ) {
+  dispatch({ type: 'LOAD_START' });
   try {
     const fileCollection =
       files instanceof FileCollection
@@ -23,5 +24,7 @@ export async function loadFiles(
     dispatch({ type: 'ADD_MEASUREMENTS', payload: measurements });
   } catch (error) {
     reportError(error);
+  } finally {
+    dispatch({ type: 'LOAD_STOP' });
   }
 }

--- a/src/pages/demo/MainLayout.tsx
+++ b/src/pages/demo/MainLayout.tsx
@@ -11,7 +11,7 @@ import { useKbsGlobal } from 'react-kbs';
 
 import {
   download,
-  getCurrentMeasurementData,
+  getExistingMeasurementKinds,
   useAppState,
 } from '../../app-data/index';
 import {
@@ -27,6 +27,7 @@ import {
   Accordion,
   DropZoneContainer,
   FullscreenToolbarButton,
+  FullSpinner,
   Header,
   SplitPane,
   Toolbar,
@@ -54,7 +55,10 @@ function ErrorFallback({
 
 export default function MainLayout() {
   const appState = useAppState();
-  const measurement = getCurrentMeasurementData(appState);
+
+  const measurementKinds = getExistingMeasurementKinds(
+    appState.data.measurements,
+  );
   useLoadFileCollectionFromHash(loadFiles);
   const onDrop = useDropFiles(loadFiles);
 
@@ -157,9 +161,15 @@ export default function MainLayout() {
                   height: '100%',
                 }}
               >
-                <DropZoneContainer onDrop={onDrop}>
-                  {measurement ? <ExplorerPlotView /> : null}
-                </DropZoneContainer>
+                {appState.load.isLoading ? (
+                  <div style={{ width: '100%', height: '100%' }}>
+                    <FullSpinner />
+                  </div>
+                ) : (
+                  <DropZoneContainer onDrop={onDrop}>
+                    {measurementKinds.length > 0 ? <ExplorerPlotView /> : null}
+                  </DropZoneContainer>
+                )}
               </div>
             </ErrorBoundary>
             <div

--- a/src/pages/demo/helpers/loadFiles.ts
+++ b/src/pages/demo/helpers/loadFiles.ts
@@ -39,6 +39,7 @@ export async function loadFiles(
   files: File[] | FileCollection,
   dispatch: AppDispatch,
 ) {
+  dispatch({ type: 'LOAD_START' });
   try {
     // try FC and File[] separately to avoid indexing error
     if (files instanceof FileCollection) {
@@ -61,6 +62,8 @@ export async function loadFiles(
     }
   } catch (error) {
     reportError(error);
+  } finally {
+    dispatch({ type: 'LOAD_STOP' });
   }
 }
 


### PR DESCRIPTION
Closes: https://github.com/zakodium-oss/analysis-ui-components/issues/408
